### PR TITLE
fix: typo in publish command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ required (like endpoints) if you use OIDC auto discovery!
 You can also publish the config file (`config/oidc.php`) if you want:
 
 ```powershell
-php artisan vendor:publish --provider ="Maicol07\OIDCClient\OIDCServiceProvider"
+php artisan vendor:publish --provider="Maicol07\OIDCClient\OIDCServiceProvider"
 ```
 
 > Note: The following options are adjustable only in the config file (there is no ENV variable):


### PR DESCRIPTION
Copy/paste the command to publish the config file resulted in this
message : `No publishable resources for tag [].`.

Signed-off-by: Eric Villard <dev@eviweb.fr>