### PR TITLE
Fix CookieJar and EventDispatcher initialization

### DIFF
--- a/src/OIDCServiceProvider.php
+++ b/src/OIDCServiceProvider.php
@@ -47,7 +47,8 @@ class OIDCServiceProvider extends ServiceProvider
 
             $guard->setCookieJar($app['cookie']);
             $guard->setDispatcher($app['events']);
-
+            $guard->setRequest($app->refresh('request', $guard, 'setRequest'));
+            
             return $guard;
         });
     }

--- a/src/OIDCServiceProvider.php
+++ b/src/OIDCServiceProvider.php
@@ -38,12 +38,17 @@ class OIDCServiceProvider extends ServiceProvider
         $this->loadRoutesFrom(__DIR__.'/routes.php');
 
         Auth::extend('oidc', static function (Application $app): OIDCGuard {
-            return new OIDCGuard(
+            $guard = new OIDCGuard(
                 'oidc',
                 new OIDCUserProvider,
                 $app['session.store'],
                 $app
             );
+
+            $guard->setCookieJar($app['cookie']);
+            $guard->setDispatcher($app['events']);
+
+            return $guard;
         });
     }
 }


### PR DESCRIPTION
## Summary

This PR fixes `OIDCGuard` initialization by configuring the underlying `SessionGuard` with the required `CookieJar` and event dispatcher.

Without these dependencies, calling `logout()` throws:

```
RuntimeException: Cookie jar has not been set.
```

### Changes

After creating the `OIDCGuard`, this PR calls:

```php
$guard->setCookieJar($app['cookie']);
$guard->setDispatcher($app['events']);
```

This matches how Laravel configures its own `SessionGuard`.

### Tested

* PHP 8.4
* Laravel 13.15
* maicol07/laravel-oidc-client 1.1.2
* Matrix Authentication Service (MAS)

Login and logout now work correctly.

Fixes #8

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OIDC authentication guard initialization so cookie handling and event dispatching are set up correctly during authentication, leading to more reliable sign-in behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->